### PR TITLE
Add csv export

### DIFF
--- a/models/message.ts
+++ b/models/message.ts
@@ -6,6 +6,7 @@ export interface Message {
   user: string;
   ts: string;
   team?: string;
+  channel: string;
   user_team?: string;
   source_team?: string;
   user_profile?: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5744,6 +5744,11 @@
         "warning": "^4.0.3"
       }
     },
+    "react-csv": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.0.3.tgz",
+      "integrity": "sha512-exyAdFLAxtuM4wNwLYrlKyPYLiJ7e0mv9tqPAd3kq+k1CiJFtznevR3yP0icv5q/y200w+lzNgi7TQn1Wrhu0w=="
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "9.4.4",
     "react": "16.13.1",
     "react-bootstrap": "^1.0.1",
+    "react-csv": "^2.0.3",
     "react-dom": "16.13.1",
     "recharts": "^1.8.5",
     "swr": "^0.2.2",

--- a/pages/api/channels/[channelName].ts
+++ b/pages/api/channels/[channelName].ts
@@ -19,6 +19,10 @@ export async function getMessagesForChannel(channelName: string | string[]) {
         "utf8"
       );
       const file_messages = JSON.parse(file_messages_json_string);
+      const messages_with_channel_name = file_messages.map( (m: Message) => {
+        m['channel'] = channelName as string;
+        return m;
+      })
       messages = messages.concat(file_messages);
     })
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,17 +3,10 @@ import ChannelList from "components/channelList";
 import Layout from "components/layout";
 import MemberTable from "components/memberTable";
 import KeywordSearch from "components/keywordSearch";
+import {dataForCSVDownload} from "utils/plotting"
 import Button from "react-bootstrap/Button";
 // CSV Export based on https://stackoverflow.com/a/48763316
 import {CSVLink, CSVDownload} from 'react-csv';
-
-const getDataForCSVDownload = () => {
-  return [
-    ["header1","header2","header3"],
-    ["data1-1","data1-2",3],
-    ["data2-1","data3-1",3],
-  ]
-}
 
 export default function Home() {
   const { data } = useSWR("/api/channels");
@@ -30,7 +23,7 @@ export default function Home() {
       return (
         <Layout>
           <>
-            <CSVLink data={getDataForCSVDownload()} >Download CSV</CSVLink>
+            <CSVLink data={dataForCSVDownload(messages, users)} >Download CSV</CSVLink>
             <h1>A list of slack channels should appear here:</h1>
             <MemberTable channel={workspace} users={users} messages={messages} />
             <KeywordSearch users={users} messages={messages} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import ChannelList from "components/channelList";
 import Layout from "components/layout";
 import MemberTable from "components/memberTable";
 import KeywordSearch from "components/keywordSearch";
+import Button from "react-bootstrap/Button";
 
 export default function Home() {
   const { data } = useSWR("/api/channels");
@@ -19,6 +20,9 @@ export default function Home() {
       return (
         <Layout>
           <>
+            <Button>
+              CSV Export
+            </Button>
             <h1>A list of slack channels should appear here:</h1>
             <MemberTable channel={workspace} users={users} messages={messages} />
             <KeywordSearch users={users} messages={messages} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,10 +4,15 @@ import Layout from "components/layout";
 import MemberTable from "components/memberTable";
 import KeywordSearch from "components/keywordSearch";
 import Button from "react-bootstrap/Button";
+// CSV Export based on https://stackoverflow.com/a/48763316
+import {CSVLink, CSVDownload} from 'react-csv';
 
-
-const doCSVExport = () => {
-  console.log("doCSVExport");
+const getDataForCSVDownload = () => {
+  return [
+    ["header1","header2","header3"],
+    ["data1-1","data1-2",3],
+    ["data2-1","data3-1",3],
+  ]
 }
 
 export default function Home() {
@@ -25,9 +30,7 @@ export default function Home() {
       return (
         <Layout>
           <>
-            <Button onClick={doCSVExport}>
-              CSV Export
-            </Button>
+            <CSVLink data={getDataForCSVDownload()} >Download CSV</CSVLink>
             <h1>A list of slack channels should appear here:</h1>
             <MemberTable channel={workspace} users={users} messages={messages} />
             <KeywordSearch users={users} messages={messages} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,11 @@ import MemberTable from "components/memberTable";
 import KeywordSearch from "components/keywordSearch";
 import Button from "react-bootstrap/Button";
 
+
+const doCSVExport = () => {
+  console.log("doCSVExport");
+}
+
 export default function Home() {
   const { data } = useSWR("/api/channels");
   if (data) {
@@ -20,7 +25,7 @@ export default function Home() {
       return (
         <Layout>
           <>
-            <Button>
+            <Button onClick={doCSVExport}>
               CSV Export
             </Button>
             <h1>A list of slack channels should appear here:</h1>

--- a/utils/plotting.ts
+++ b/utils/plotting.ts
@@ -110,7 +110,7 @@ const dataRowForMessage = (message: Message, users: User[]) => {
 // refactor.  It is here for now so that we can use the other
 // functions in this file as a guide.
 export function dataForCSVDownload(messages: Message[], users: User[]) {
-  resolveIDs(messages,users);
+  // resolveIDs(messages,users);
 
   const headers = ["timestamp","personId","teamID","type","messageId","messageBody","taggedPeople"];
   console.log(JSON.stringify(messages,null,2));

--- a/utils/plotting.ts
+++ b/utils/plotting.ts
@@ -2,7 +2,7 @@ import { Message } from "models/message";
 import { User } from "models/user";
 import { userMapFromList, notEmpty } from "./general";
 import { Dictionary } from "typescript-collections";
-import { resolveIDs, listOfTaggedUsers } from "./slack";
+import { resolveIDs, listOfTaggedUsers, replaceSlackIDsWithReadableIDs } from "./slack";
 
 export interface SimpleData {
   value: number;
@@ -94,7 +94,9 @@ const dataRowForMessage = (message: Message, users: User[]) => {
   let messageType = "postMessage ";
   let messageId = message.channel + "-" + message.ts;
   let messageBody = message.text.replace(/"/g, '&quot;').replace(/'/g,'&apos;');
+  messageBody = replaceSlackIDsWithReadableIDs(messageBody,userMap);
   let taggedPeople = listOfTaggedUsers(message,userMap);
+  taggedPeople = replaceSlackIDsWithReadableIDs(taggedPeople,userMap);
   return [ 
     timestamp,
     personId,

--- a/utils/plotting.ts
+++ b/utils/plotting.ts
@@ -73,6 +73,37 @@ export function messagesPerUser(messages: Message[], users: User[]) {
     .sort((a, b) => b.value - a.value);
 }
 
+const dataRowForMessage = (message: Message) => {
+  let timestamp = message.ts;
+  let personId = "person-TBD";
+  let teamID = "team-TBD";
+  let messageType = "postMessage ";
+  let messageId = message.channel + "-" + message.ts;
+  let messageBody = message.text;
+  let taggedPeople = "[taggedTBD1,taggedTBD2]";
+  return [ 
+    timestamp,
+    personId,
+    teamID,
+    messageType,
+    messageId,
+    messageBody,
+    taggedPeople
+  ];
+}
+
+// This should moved out of plotting.ts as part of a later
+// refactor.  It is here for now so that we can use the other
+// functions in this file as a guide.
+export function dataForCSVDownload(messages: Message[], users: User[]) {
+  const headers = ["timestamp","personId","teamID","type","messageId","messageBody","taggedPeople"];
+  console.log(JSON.stringify(messages,null,2));
+  const dataRows = messages.map( (message) => dataRowForMessage(message) );
+  let result = [ headers ];
+  result = result.concat(dataRows);
+  return result
+}
+
 export interface UserPair {
   respondee: string;
   responder: string;

--- a/utils/slack.ts
+++ b/utils/slack.ts
@@ -12,7 +12,13 @@ export function listOfTaggedUsers(
   message: Message,
   userMap: { [id: string]: User }
 ) {
-  return "[TBD]";
+
+  // count the number of times that slackIDRegex occurs in message.text
+  // That's the number of tagged users.
+  // For each of those matches, get the user.name of that tagged user
+
+  let matches = message.text.match(slackIDRegex) || [];
+  return matches.toString();
 }
 
 

--- a/utils/slack.ts
+++ b/utils/slack.ts
@@ -1,11 +1,20 @@
 import { Message } from "models/message";
 import { User } from "models/user";
+import { userMapFromList } from "./general";
 
 const slackIDRegex = /<@(U\w+)>/gi;
 
 export function sortedMessages(messages: Message[]) {
   return messages.sort((a: Message, b: Message) => Number(a.ts) - Number(b.ts));
 }
+
+export function listOfTaggedUsers(
+  message: Message,
+  userMap: { [id: string]: User }
+) {
+  return "[TBD]";
+}
+
 
 export function resolveMessageIDs(
   message: Message,
@@ -29,10 +38,7 @@ export function resolveMessageIDs(
 }
 
 export function resolveIDs(messages: Message[], users: User[]) {
-  let userMap: { [id: string]: User } = {};
-  for (const user of users) {
-    userMap[user.id] = user;
-  }
+  let userMap = userMapFromList(users);
   for (let message of messages) {
     resolveMessageIDs(message, userMap);
   }

--- a/utils/slack.ts
+++ b/utils/slack.ts
@@ -37,10 +37,18 @@ export function resolveMessageIDs(
     message.text = "We are unable to display bot messages at this time.";
     message.user_profile.real_name = "[BOT] " + message.user_profile.real_name;
   } else {
-    message.text = message.text.replace(slackIDRegex, (match, p1) => {
-      return "@" + userMap[p1].real_name;
-    });
+    message.text = replaceSlackIDsWithReadableIDs(message.text,userMap);
   }
+}
+
+export function replaceSlackIDsWithReadableIDs(
+  s: string,
+  userMap: { [id: string]: User }
+) {
+  return s.replace(
+    slackIDRegex,
+    (match, p1) => { return "@" + userMap[p1].real_name; }
+  );
 }
 
 export function resolveIDs(messages: Message[], users: User[]) {


### PR DESCRIPTION
In this PR, we add the ability to export a CSV file containing one row for each slack message in the archive.

All columns are functional except for team id.   We'll handle that column in a separate pull request.