### PR TITLE
pc - fix bug in CSV Download

### DIFF
--- a/utils/plotting.ts
+++ b/utils/plotting.ts
@@ -51,11 +51,11 @@ export function messagesToData(messages: Message[]) {
 }
 
 export function getUserName(user: User) {
-  return user.name;
+  return user ? user.name : "";
 }
 
 export function getHumanReadableName(user: User) {
-  var retVal = user.profile.display_name || user.profile.real_name;
+  return user ? (user.profile.display_name || user.profile.real_name ) : "";
 }
 
 export function messagesPerUser(messages: Message[], users: User[]) {


### PR DESCRIPTION
In some cases, user was nil and the CSV Download code was choking on this.
This commit adds guard clauses to avoid those errors.