### PR TITLE
Add team id to csv export

### DIFF
--- a/models/roster_student.ts
+++ b/models/roster_student.ts
@@ -1,0 +1,14 @@
+export interface RosterStudent {
+    perm: string;
+    email: string;
+    first_name: string;
+    last_name: string;
+    enrolled: boolean;
+    section: string;
+    username?: string;
+    slack_uid?: string;
+    slack_username?: string;
+    slack_display_name?: string;
+    org_member_status?: string;
+    teams?: string;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,6 +16,7 @@ export default function Home() {
       const channels = data.channels;
       const messages = data.messages;
       const users = data.users;
+      const slack2team = data.slack2team;
       const workspace = {
         name: "Workspace",
         members: users,
@@ -23,7 +24,7 @@ export default function Home() {
       return (
         <Layout>
           <>
-            <CSVLink data={dataForCSVDownload(messages, users)} >Download CSV</CSVLink>
+            <CSVLink data={dataForCSVDownload(messages, users, slack2team)} >Download CSV</CSVLink>
             <h1>A list of slack channels should appear here:</h1>
             <MemberTable channel={workspace} users={users} messages={messages} />
             <KeywordSearch users={users} messages={messages} />

--- a/utils/plotting.ts
+++ b/utils/plotting.ts
@@ -51,11 +51,11 @@ export function messagesToData(messages: Message[]) {
 }
 
 export function getUserName(user: User) {
-  return user.name;
+  return user ? user.name : "";
 }
 
 export function getHumanReadableName(user: User) {
-  var retVal = user.profile.display_name || user.profile.real_name;
+  return user ? (user.profile.display_name || user.profile.real_name ) : "";
 }
 
 export function messagesPerUser(messages: Message[], users: User[]) {


### PR DESCRIPTION
This PR adds team information to the CSV Export for messages where the team can be determined.

This depends on having a file roster-students.json in the public/data directory.
The format of that file current matches the format exported from the anacapa-github-linker.